### PR TITLE
Install powershell and wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ FROM amazon/aws-cli:latest
 ENV AWS_ACCESS_KEY_ID mock-key
 ENV AWS_SECRET_ACCESS_KEY mock-secret
 
+# Install powershell
+RUN yum install -y https://github.com/PowerShell/PowerShell/releases/download/v7.0.3/powershell-lts-7.0.3-1.rhel.7.x86_64.rpm
+
 # Upgrade node and install python3
 RUN curl https://rpm.nodesource.com/setup_12.x | bash -
-RUN yum -y install nodejs python3 unzip
+RUN yum -y install nodejs python3 unzip wget
 RUN rm /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 


### PR DESCRIPTION
Installs powershell and wget in the sandbox image.

Note: Powershell needs to be installed before python or the installer script itself fails.

Closes #3 and #4

![image](https://user-images.githubusercontent.com/1521394/91752302-c6696980-eb8b-11ea-92af-400f45f624ad.png)
